### PR TITLE
Use Plack::Util::Accesor instead of Moo in order to reducing dependencies

### DIFF
--- a/META.yml
+++ b/META.yml
@@ -17,7 +17,6 @@ meta-spec:
   version: 1.4
 name: Plack-Middleware-GoogleAnalytics
 requires:
-  Moo: 0
   Plack::Util: 0
   Text::MicroTemplate: 0
 version: 0.001

--- a/Makefile.PL
+++ b/Makefile.PL
@@ -25,7 +25,6 @@ my %WriteMakefileArgs = (
   "LICENSE" => "perl",
   "NAME" => "Plack::Middleware::GoogleAnalytics",
   "PREREQ_PM" => {
-    "Moo" => 0,
     "Plack::Util" => 0,
     "Text::MicroTemplate" => 0
   },

--- a/README.mkdn
+++ b/README.mkdn
@@ -23,7 +23,7 @@ This is the id that is supplied by Google. This is a required argument.
 
 # SEE ALSO
 
-[Plack](http://search.cpan.org/perldoc?Plack), [Plack::Middleware](http://search.cpan.org/perldoc?Plack::Middleware), [Moo](http://search.cpan.org/perldoc?Moo) 
+[Plack](http://search.cpan.org/perldoc?Plack), [Plack::Middleware](http://search.cpan.org/perldoc?Plack::Middleware)
 
 # AUTHOR
 

--- a/dist.ini
+++ b/dist.ini
@@ -8,7 +8,6 @@ abstract            = Middleware to apply Google Anlytics javascript code.
 
 [@Basic]
 [Prereqs]
-Moo = 0
 Plack::Util = 0
 Text::MicroTemplate = 0
 


### PR DESCRIPTION
Hi, @logie17 .

I found this OSS in http://www.cpan.org/, and now I want to use this.  But unfortunately my project cannot depend on `Moo`.

So this PR removes Moo dependencies with using Plack::Util::Accessor.

Anyway, thank you for your OSS activity!